### PR TITLE
#34: Advanced Transactions Read API

### DIFF
--- a/backend-core/src/transactions/dto/get-transactions.dto.ts
+++ b/backend-core/src/transactions/dto/get-transactions.dto.ts
@@ -1,0 +1,120 @@
+import {
+  IsOptional,
+  IsString,
+  IsInt,
+  Min,
+  IsDate,
+  IsArray,
+  IsEnum,
+  IsNumber,
+} from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+// export const SortOrder = {
+//   ASC: 'asc',
+//   DESC: 'desc',
+// } as const;
+
+export enum SortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+export class GetTransactionsFilterDto {
+  // --- Filters ---
+  @ApiPropertyOptional({
+    description: 'Search text in details, operation, or category',
+    example: 'Amazon',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by start date (ISO 8601)',
+    example: '2025-01-01T00:00:00.000Z',
+    type: Date,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  startDate?: Date;
+
+  @ApiPropertyOptional({
+    description: 'Filter by end date (ISO 8601)',
+    example: '2025-12-31T23:59:59.999Z',
+    type: Date,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  endDate?: Date;
+
+  @ApiPropertyOptional({ description: 'Minimum amount', example: -100.5 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  minAmount?: number;
+
+  @ApiPropertyOptional({ description: 'Maximum amount', example: 987 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  maxAmount?: number;
+
+  @ApiPropertyOptional({
+    description: 'Filter by categories (comma separated)',
+    example: 'FOOD,HOME',
+    type: String, // Swagger -> string, Transform -> array
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @Type(() => String)
+  @Transform(({ value }: { value: unknown }) => {
+    if (typeof value === 'string') {
+      return value.split(',');
+    }
+    return value as string[];
+  })
+  categories?: string[];
+
+  // --- Pagination ---
+  @ApiPropertyOptional({ description: 'Page number', default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    default: 10,
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit: number = 10;
+
+  // --- Sorting ---
+  @ApiPropertyOptional({
+    description: 'Field to sort by',
+    default: 'date',
+    example: 'amount',
+  })
+  @IsOptional()
+  @IsString()
+  sortBy: string = 'date';
+
+  @ApiPropertyOptional({
+    description: 'Sort order',
+    enum: SortOrder,
+    default: SortOrder.DESC,
+  })
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortOrder: SortOrder = SortOrder.DESC;
+}

--- a/backend-core/src/transactions/dto/transaction-response.dto.ts
+++ b/backend-core/src/transactions/dto/transaction-response.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class EnrichedTransactionDto {
+  @ApiProperty({ example: 'uuid-1234-...' })
+  id: string;
+
+  @ApiProperty({ example: '2025-01-01T12:00:00Z' })
+  date: Date;
+
+  @ApiProperty({ example: -50.5 })
+  amount: number;
+
+  @ApiProperty({ example: 'Pagamento POS' })
+  operation: string;
+
+  @ApiProperty({ example: 'Amazon IT' })
+  details: string;
+
+  @ApiProperty({ example: 'Conto Corrente X' })
+  account: string;
+
+  @ApiProperty({ example: 'SHOPPING', description: 'Macro category' })
+  category: string;
+
+  @ApiProperty({
+    example: 'Electronics',
+    description: 'Translated sub-category',
+    required: false,
+  })
+  subCategory?: string;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+}
+
+export class PaginationMetaDto {
+  @ApiProperty({ example: 100, description: 'Total number of items found' })
+  total: number;
+
+  @ApiProperty({ example: 1, description: 'Current page' })
+  page: number;
+
+  @ApiProperty({ example: 10, description: 'Total pages available' })
+  lastPage: number;
+
+  @ApiProperty({ example: 10, description: 'Number of items in this response' })
+  count: number;
+}
+
+export class PaginatedTransactionsResponseDto {
+  @ApiProperty({
+    type: [EnrichedTransactionDto],
+    description: 'List of transactions',
+  })
+  data: EnrichedTransactionDto[];
+
+  @ApiProperty({ type: PaginationMetaDto, description: 'Pagination metadata' })
+  meta: PaginationMetaDto;
+}

--- a/backend-core/src/transactions/transactions.controller.ts
+++ b/backend-core/src/transactions/transactions.controller.ts
@@ -6,6 +6,9 @@ import {
   UploadedFile,
   ParseFilePipeBuilder,
   HttpStatus,
+  UsePipes,
+  Query,
+  ValidationPipe,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
@@ -17,6 +20,8 @@ import {
 } from '@nestjs/swagger';
 import { TransactionsService } from './transactions.service';
 import { UploadTransactionResponseDto } from './dto/upload-transaction-response.dto';
+import { GetTransactionsFilterDto } from './dto/get-transactions.dto';
+import { PaginatedTransactionsResponseDto } from './dto/transaction-response.dto';
 
 @ApiTags('Transactions')
 @Controller('transactions')
@@ -67,10 +72,25 @@ export class TransactionsController {
     return this.transactionsService.uploadFile(file);
   }
 
+  @Get('raw')
+  @ApiOperation({ summary: 'Get all RAW transactions (Debug only)' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of raw transactions direct from DB',
+  })
+  async findAllRaw() {
+    return this.transactionsService.getAllTransactionsRaw();
+  }
+
   @Get()
-  @ApiOperation({ summary: 'Get all raw transactions' })
-  @ApiResponse({ status: 200, description: 'List of raw transactions' })
-  async findAll() {
-    return this.transactionsService.getAllTransactions();
+  @ApiOperation({ summary: 'Search and filter enriched transactions' })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of enriched transactions',
+    type: PaginatedTransactionsResponseDto,
+  })
+  @UsePipes(new ValidationPipe({ transform: true }))
+  async findAllEnriched(@Query() filters: GetTransactionsFilterDto) {
+    return this.transactionsService.getTransactionsEnriched(filters);
   }
 }

--- a/backend-core/src/transactions/transactions.repository.ts
+++ b/backend-core/src/transactions/transactions.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { Prisma } from '@prisma/client';
+import { GetTransactionsFilterDto } from './dto/get-transactions.dto';
 
 @Injectable()
 export class TransactionsRepository {
@@ -24,5 +25,63 @@ export class TransactionsRepository {
     return this.prisma.enrichedTransaction.createMany({
       data,
     });
+  }
+
+  async findAllEnriched(filters: GetTransactionsFilterDto) {
+    const {
+      page,
+      limit,
+      startDate,
+      endDate,
+      search,
+      categories,
+      minAmount,
+      maxAmount,
+      sortBy,
+      sortOrder,
+    } = filters;
+
+    const conditions: Prisma.EnrichedTransactionWhereInput[] = [];
+
+    if (startDate) conditions.push({ date: { gte: startDate } });
+    if (endDate) conditions.push({ date: { lte: endDate } });
+
+    if (minAmount !== undefined)
+      conditions.push({ amount: { gte: minAmount } });
+    if (maxAmount !== undefined)
+      conditions.push({ amount: { lte: maxAmount } });
+
+    if (categories && categories.length > 0) {
+      conditions.push({ category: { in: categories } });
+    }
+
+    if (search) {
+      conditions.push({
+        OR: [
+          // contains is case-insensitive by default in SQLite
+          { details: { contains: search } },
+          { operation: { contains: search } },
+          { subCategory: { contains: search } },
+          { category: { contains: search } },
+        ],
+      });
+    }
+
+    const where: Prisma.EnrichedTransactionWhereInput =
+      conditions.length > 0 ? { AND: conditions } : {};
+
+    const [total, transactions] = await this.prisma.$transaction([
+      this.prisma.enrichedTransaction.count({ where }),
+      this.prisma.enrichedTransaction.findMany({
+        where,
+        take: limit,
+        skip: (page - 1) * limit,
+        orderBy: {
+          [sortBy]: sortOrder,
+        },
+      }),
+    ]);
+
+    return { total, transactions };
   }
 }

--- a/backend-core/src/transactions/transactions.service.ts
+++ b/backend-core/src/transactions/transactions.service.ts
@@ -6,6 +6,7 @@ import { TransactionsRepository } from './transactions.repository';
 import { BankExportRow } from './interfaces/bank-export-row.interface';
 import { ScienceService } from 'src/science/science.service';
 import { ProcessedTransaction } from 'src/science/interfaces/processed-transaction.interface';
+import { GetTransactionsFilterDto } from './dto/get-transactions.dto';
 
 @Injectable()
 export class TransactionsService {
@@ -132,7 +133,22 @@ export class TransactionsService {
       },
     };
   }
-  async getAllTransactions() {
+  async getAllTransactionsRaw() {
     return this.repository.findAllRaw();
+  }
+
+  async getTransactionsEnriched(filters: GetTransactionsFilterDto) {
+    const { total, transactions } =
+      await this.repository.findAllEnriched(filters);
+
+    return {
+      data: transactions,
+      meta: {
+        total,
+        page: filters.page,
+        lastPage: Math.ceil(total / filters.limit),
+        count: transactions.length,
+      },
+    };
   }
 }


### PR DESCRIPTION
Closes #34

Introduces an advanced `/transactions` endpoint enabling rich filtering by text, date, amount, and categories, along with sorting and pagination for enriched transaction data.

This update includes:
- New DTOs (`GetTransactionsFilterDto`, `PaginatedTransactionsResponseDto`) to define request and response structures, integrating `class-validator` and `class-transformer` for robust validation and data transformation.
- Repository logic to dynamically construct Prisma queries for enriched transactions based on filter criteria.
- A dedicated `/transactions/raw` endpoint for fetching all raw transactions, separating it from the new paginated and filtered view.
